### PR TITLE
Fixes to Model page

### DIFF
--- a/src/pages/model/Model.js
+++ b/src/pages/model/Model.js
@@ -1,6 +1,6 @@
 import React from "react";
 import {Grid, withStyles,} from "@material-ui/core";
-import {ComposedChart, Line, ResponsiveContainer, XAxis, YAxis} from "recharts";
+import {LineChart, Tooltip, CartesianGrid, Line, ResponsiveContainer, XAxis, YAxis} from "recharts";
 
 import ModelWidget from "../../components/ModelWidget";
 import {Typography} from "../../components/Wrappers";
@@ -60,7 +60,7 @@ const Model = ({classes, theme, ...props}) => {
                     >
                         <div className={classes.visitsNumberContainer}>
                             <Typography size="xl" weight="medium">
-                                $10/$100
+                                ${500 * props.metrics.improvement/100}/$500
                             </Typography>
                         </div>
                         <Grid
@@ -99,22 +99,19 @@ const Model = ({classes, theme, ...props}) => {
                         }
                     >
                         <ResponsiveContainer width="100%" minWidth={500} height={350}>
-                            <ComposedChart
-                                margin={{top: 0, right: -15, left: -15, bottom: 0}}
+                            <LineChart
+                                margin={{top: 0, right: 10, left: 10, bottom: 0}}
                                 data={props.chart.data}
                             >
+                                <CartesianGrid strokeDasharray="3 3" />
                                 <YAxis
-                                    ticks={[0, 1000, 2000, 5000, 10000, 30000]}
-                                    tick={{fill: theme.palette.text.hint + '80', fontSize: 14}}
-                                    stroke={theme.palette.text.hint + '80'}
-                                    tickLine={false}
+                                    scale='log'
+                                    domain={['auto', 'dataMax + 1000']}
                                 />
                                 <XAxis
                                     tickFormatter={i => i + 1}
-                                    tick={{fill: theme.palette.text.hint + '80', fontSize: 14}}
-                                    stroke={theme.palette.text.hint + '80'}
-                                    tickLine={false}
                                 />
+                                <Tooltip />
                                 <Line
                                     type="natural"
                                     dataKey="initial"
@@ -125,16 +122,15 @@ const Model = ({classes, theme, ...props}) => {
                                     strokeDasharray="5 5"
                                 />
                                 <Line
-                                    type="natural"
+                                    type="monotone"
                                     dataKey="partial"
                                     stroke={theme.palette.primary.main}
-                                    strokeWidth={2}
+                                    strokeWidth={1}
                                     dot={{
                                         stroke: theme.palette.primary.main,
-                                        strokeWidth: 2,
-                                        fill: theme.palette.primary.main
+                                        strokeWidth: 1,
                                     }}
-                                    activeDot={false}
+                                    activeDot={{ r: 8 }}
                                 />
                                 <Line
                                     type="linear"
@@ -144,7 +140,7 @@ const Model = ({classes, theme, ...props}) => {
                                     strokeDasharray="5 5"
                                     dot={false}
                                 />
-                            </ComposedChart>
+                            </LineChart>
                         </ResponsiveContainer>
                     </ModelWidget>
                 </Grid>

--- a/src/pages/model/components/Table/Table.js
+++ b/src/pages/model/components/Table/Table.js
@@ -16,17 +16,17 @@ const TableComponent = ({ classes,...props }) => {
         <TableRow>
             <TableCell>Data Owner</TableCell>
             <TableCell>MSE</TableCell>
-            <TableCell>Improvement%</TableCell>
-            <TableCell>Pay</TableCell>
+            <TableCell>Contribution (%)</TableCell>
+            <TableCell>Pay (eth)</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
-        {props.rowsData.map(({ data_owner, partial_MSE}) => (
+        {props.rowsData.map(({ data_owner, partial_MSE, payment, contributions}) => (
           <TableRow key={data_owner}>
             <TableCell >{data_owner}</TableCell>
             <TableCell>{partial_MSE}</TableCell>
-            <TableCell>{partial_MSE}</TableCell>
-            <TableCell>{partial_MSE}</TableCell>
+            <TableCell>{contributions} %</TableCell>
+            <TableCell>{payment} eth</TableCell>
           </TableRow>
         ))}
       </TableBody>


### PR DESCRIPTION
This PR has to be merge along side with [this one from model-buyer](https://github.com/DeltaML/model-buyer/pull/39).

The changes in this PR include:
- Changed scale of chart to logarithmic to show better the improvement across iterations,
- Aesthetic changes to the chart (now is more interactive).
- Fixed info about data owners: 
  - Before, the columns 'contrib' and 'pay' where showing the partial_mse. Now they are showing the correct metrics.
  - Rounded the numbers to 2 digits.
  - Added the units for the numbers.
- The metric 'Spent Money' is now being updated. It uses the contributions and improvement of the model to calculate the value of the spent money (done in the backend).

![Captura de pantalla_2019-10-09_16-36-38](https://user-images.githubusercontent.com/8533854/66514406-6b321280-eab3-11e9-8019-9cab375ec0d2.png)
![Captura de pantalla_2019-10-09_16-36-19](https://user-images.githubusercontent.com/8533854/66514410-6f5e3000-eab3-11e9-8bd3-6d9d985f5189.png)
![Captura de pantalla_2019-10-09_16-35-27](https://user-images.githubusercontent.com/8533854/66514413-738a4d80-eab3-11e9-8fee-2099b1413a88.png)
